### PR TITLE
fix flaky test testGenericTypeInconsistency

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeList.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeList.java
@@ -37,6 +37,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -959,7 +960,14 @@ public interface TypeList extends FilterableList<TypeDescription, TypeList> {
              * {@inheritDoc}
              */
             public TypeDescription.Generic get(int index) {
-                return new OfMethodExceptionTypes.TypeProjection(method, index, method.getExceptionTypes());
+                Class<?>[] exceptionTypes = method.getExceptionTypes();
+                Arrays.sort(exceptionTypes, new Comparator<Class<?>>() {
+                    @Override
+                    public int compare(Class<?> aClass, Class<?> t1) {
+                        return aClass.getCanonicalName().compareTo(t1.getCanonicalName());
+                    }
+                });
+                return new OfMethodExceptionTypes.TypeProjection(method, index, exceptionTypes);
             }
 
             /**


### PR DESCRIPTION
**Problem**: 

The test `TypeDescriptionArrayProjectionTest.testGenericTypeInconsistency` is found to be flaky because it assumes the order of the array that is being returned and compared for assertion. (in this case exceptions).

We found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

**Cause**: 

This is being done on the following lines in AbstractTypeDescriptionGenericTest.java:
`assertThat(typeDescription.getDeclaredMethods().filter(named(FOO)).getOnly().getExceptionTypes().get(0).asErasure().represents(Exception.class),
                is(true));` (Line 1271)
`assertThat(typeDescription.getDeclaredMethods().filter(named(FOO)).getOnly().getExceptionTypes().get(1).represents(RuntimeException.class),
                is(true));` (Line 1275)


The function `getExceptionTypes().get(index)` returns the exceptions of the methods as an array in a random fashion on running the non dex tool which is the cause of the non-determinism.
It flips `java.lang.Exception` and `java.lang.RuntimeException` which is the cause of the test failure as the test requires the order to maintained (Line 1271,1275)
This non-deterministic behaviour of `get(index)` is because it uses java's reflection API to fetch the exception types `getExceptionTypes`, so there is no guarantee in order of the returned fields on different iterations

**Fix**:

This PR proposes to sort the returned fields in `get(index)` function in `byte-buddy/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeList.java` and make the test deterministic. There are multiple ways to address this issue, with lambda functions but I had faced an error for using lamdba functions for this java version (8) hence used a comparator to sort the values